### PR TITLE
Update manifest to avoid merge conflict when using library.

### DIFF
--- a/simple-storage/src/main/AndroidManifest.xml
+++ b/simple-storage/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest package="com.sromku.simple.storage"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        >
-
-    </application>
-
-</manifest>
+<manifest package="com.sromku.simple.storage"/>


### PR DESCRIPTION
Avoid this issue:
Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:25:9-36
	is also present at [com.sromku:simple-storage:1.1.0] AndroidManifest.xml:12:9-35 value=(true).
	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:24:5-71:19 to override.